### PR TITLE
Triple slash directives, review feedback option 1

### DIFF
--- a/lib/__tests__/tripleSlashDirective.test.ts
+++ b/lib/__tests__/tripleSlashDirective.test.ts
@@ -11,8 +11,9 @@ describe("an emitted module with triple slash directives", () => {
         tripleSlashDirectives.push(create.tripleSlashAmdModuleDirective("test"));
 
         const module = create.module("test");
+        const emitOptions = {rootFlags: ContextFlags.Module, tripleSlashDirectives};
 
-        expect(emit(module, ContextFlags.Module, tripleSlashDirectives)).toMatchSnapshot();
+        expect(emit(module, emitOptions)).toMatchSnapshot();
     });
 });
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -597,10 +597,17 @@ export function never(x: never, err: string): never {
     throw new Error(err);
 }
 
-export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.None, tripleSlashDirectives: TripleSlashDirective[] = []): string {
+export interface EmitOptions {
+    rootFlags?: ContextFlags;
+    tripleSlashDirectives?: TripleSlashDirective[];
+}
+
+export function emit(rootDecl: TopLevelDeclaration, options?: ContextFlags | EmitOptions): string {
     let output = "";
     let indentLevel = 0;
-    let contextStack: ContextFlags[] = [rootFlags];
+    const rootFlags = (typeof options === 'object' ? options.rootFlags : options) || ContextFlags.None;
+    const contextStack: ContextFlags[] = [rootFlags];
+    const tripleSlashDirectives = typeof options === 'object' && options.tripleSlashDirectives || [];
 
     tripleSlashDirectives.forEach(writeTripleSlashDirective);
 


### PR DESCRIPTION
> Option 1: The second parameter to emit could be made `ContextFlags | { rootFlags; tripleSlashDirectives }` since we can trivially differentiate the enum from the object; this would be my preferred alternative.

see https://github.com/RyanCavanaugh/dts-dom/pull/39#issuecomment-359110327