### PR TITLE
Triple slash directives, review feedback option 3

### DIFF
--- a/lib/__tests__/tripleSlashDirective.test.ts
+++ b/lib/__tests__/tripleSlashDirective.test.ts
@@ -11,8 +11,9 @@ describe("an emitted module with triple slash directives", () => {
         tripleSlashDirectives.push(create.tripleSlashAmdModuleDirective("test"));
 
         const module = create.module("test");
+        const emitOptions = {rootFlags: ContextFlags.Module, tripleSlashDirectives};
 
-        expect(emit(module, ContextFlags.Module, tripleSlashDirectives)).toMatchSnapshot();
+        expect(emit(module, emitOptions)).toMatchSnapshot();
     });
 });
 
@@ -20,6 +21,6 @@ describe("an emitted module without triple slash directives", () => {
     it("matches the snapshot", () => {
         const module = create.module("test");
 
-        expect(emit(module, ContextFlags.Module)).toMatchSnapshot();
+        expect(emit(module, {rootFlags: ContextFlags.Module})).toMatchSnapshot();
     });
 });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -597,7 +597,12 @@ export function never(x: never, err: string): never {
     throw new Error(err);
 }
 
-export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.None, tripleSlashDirectives: TripleSlashDirective[] = []): string {
+export interface EmitOptions {
+    rootFlags?: ContextFlags;
+    tripleSlashDirectives?: TripleSlashDirective[];
+}
+
+export function emit(rootDecl: TopLevelDeclaration, { rootFlags = ContextFlags.None, tripleSlashDirectives = [] }: EmitOptions = {}): string {
     let output = "";
     let indentLevel = 0;
     let contextStack: ContextFlags[] = [rootFlags];


### PR DESCRIPTION
> Option 3: Snap the current version at 1.0 and take the proposed break to emit as 2.0. Since people are using this library in earnest it'd be good to get on the real semver train.

see https://github.com/RyanCavanaugh/dts-dom/pull/39#issuecomment-359110327

closes #1, closes #3 