### PR TITLE
Triple slash directives, review feedback option 2

### DIFF
--- a/lib/__tests__/tripleSlashDirective.test.ts
+++ b/lib/__tests__/tripleSlashDirective.test.ts
@@ -1,18 +1,17 @@
-import {ContextFlags, TripleSlashDirective, create, emit} from "../index"
+import {ContextFlags, TopLevelDeclaration, create, emit} from "../index"
 
 describe("an emitted module with triple slash directives", () => {
     it("matches the snapshot", () => {
-        const tripleSlashDirectives: TripleSlashDirective[] = [];
+        const declarations: TopLevelDeclaration[] = [];
 
-        tripleSlashDirectives.push(create.tripleSlashReferencePathDirective("./test"));
-        tripleSlashDirectives.push(create.tripleSlashReferenceTypesDirective("test"));
-        tripleSlashDirectives.push(create.tripleSlashReferenceNoDefaultLibDirective());
-        tripleSlashDirectives.push(create.tripleSlashAmdModuleDirective());
-        tripleSlashDirectives.push(create.tripleSlashAmdModuleDirective("test"));
+        declarations.push(create.tripleSlashReferencePathDirective("./test"));
+        declarations.push(create.tripleSlashReferenceTypesDirective("test"));
+        declarations.push(create.tripleSlashReferenceNoDefaultLibDirective());
+        declarations.push(create.tripleSlashAmdModuleDirective());
+        declarations.push(create.tripleSlashAmdModuleDirective("test"));
+        declarations.push(create.module("test"));
 
-        const module = create.module("test");
-
-        expect(emit(module, ContextFlags.Module, tripleSlashDirectives)).toMatchSnapshot();
+        expect(emit(declarations, ContextFlags.Module)).toMatchSnapshot();
     });
 });
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -243,7 +243,7 @@ export type Import = ImportAllDeclaration | ImportDefaultDeclaration | ImportNam
 
 export type NamespaceMember = InterfaceDeclaration | TypeAliasDeclaration | ClassDeclaration | NamespaceDeclaration | ConstDeclaration | VariableDeclaration | FunctionDeclaration;
 export type ModuleMember = InterfaceDeclaration | TypeAliasDeclaration | ClassDeclaration | NamespaceDeclaration | ConstDeclaration | VariableDeclaration | FunctionDeclaration | Import;
-export type TopLevelDeclaration =  NamespaceMember | ExportEqualsDeclaration | ExportNameDeclaration | ModuleDeclaration | EnumDeclaration | Import;
+export type TopLevelDeclaration = TripleSlashDirective | NamespaceMember | ExportEqualsDeclaration | ExportNameDeclaration | ModuleDeclaration | EnumDeclaration | Import;
 
 export enum DeclarationFlags {
     None = 0,
@@ -597,14 +597,13 @@ export function never(x: never, err: string): never {
     throw new Error(err);
 }
 
-export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.None, tripleSlashDirectives: TripleSlashDirective[] = []): string {
+export function emit(rootDecl: TopLevelDeclaration | TopLevelDeclaration[], rootFlags = ContextFlags.None): string {
     let output = "";
     let indentLevel = 0;
     let contextStack: ContextFlags[] = [rootFlags];
+    let rootDeclarations = Array.isArray(rootDecl) ? rootDecl : Array(rootDecl);
 
-    tripleSlashDirectives.forEach(writeTripleSlashDirective);
-
-    writeDeclaration(rootDecl);
+    rootDeclarations.forEach(writeDeclaration);
     newline();
     return output;
 
@@ -1218,6 +1217,11 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
                     return writeImport(d);
                 case "enum":
                     return writeEnum(d);
+                case "triple-slash-reference-path":
+                case "triple-slash-reference-types":
+                case "triple-slash-reference-no-default-lib":
+                case "triple-slash-amd-module":
+                    return writeTripleSlashDirective(d);
 
                 default:
                     return never(d, `Unknown declaration kind ${(d as TopLevelDeclaration).kind}`);


### PR DESCRIPTION
> Option 2: Representing `///` directives as top-level declarations makes some amount of sense, too, even though it's a lie. We could make emit take `TopLevelDeclaration[] | TopLevelDeclaration` as its first parameter so callers don't have to manually stitch them together; this seems pretty intuitive. I think it's an open question whether dts-dom itself would do the sorting in that scenario.

see https://github.com/RyanCavanaugh/dts-dom/pull/39#issuecomment-359110327